### PR TITLE
:bug: fix error handling in container exec

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -129,8 +129,8 @@ impl App {
                     Action::Screen(ref screen) => {
                         let mut new_main = screen.clone();
                         new_main.register_action_handler(action_tx.clone());
-                        main.teardown(&mut tui)?;
                         new_main.setup(&mut tui)?;
+                        main.teardown(&mut tui)?;
                         main = new_main;
                     }
                     Action::Change => {

--- a/src/components/images.rs
+++ b/src/components/images.rs
@@ -200,10 +200,9 @@ impl Images {
                             "Unable to delete container \"{}\" {}",
                             id, e
                         )))?;
-                    } else {
-                        self.show_popup = Popup::None;
-                        tx.send(Action::Tick)?;
                     }
+                    self.show_popup = Popup::None;
+                    tx.send(Action::Tick)?;
                 };
             }
             Action::PreviousScreen => {


### PR DESCRIPTION
Fix error handling in container exec which let a tokio task intercepting input running in the back
